### PR TITLE
Vagrant up fails when downloading Kernel file.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,8 @@ all:
 	apt-get install -y libmpfr-dev libmpc-dev
 	# https://github.com/bbcmicrobit/micropython/issues/514
 	# Ubuntu 18.04 arm-none-eabi-gcc has broken libc/nano specs (always tries to use full arm w/invalid instructions)
-	wget http://mirrors.kernel.org/ubuntu/pool/universe/n/newlib/libnewlib-dev_3.0.0.20180802-2_all.deb
-	wget http://mirrors.kernel.org/ubuntu/pool/universe/n/newlib/libnewlib-arm-none-eabi_3.0.0.20180802-2_all.deb
+	wget http://mirrors.kernel.org/ubuntu/pool/universe/n/newlib/libnewlib-doc_3.1.0.20181231-1_all.deb 
+	wget http://mirrors.kernel.org/ubuntu/pool/universe/n/newlib/libnewlib-arm-none-eabi_3.1.0.20181231-1_all.deb
 	#dpkg -i libnewlib-arm-none-eabi_3.0.0.20180802-2_all.deb libnewlib-dev_3.0.0.20180802-2_all.deb
 	dos2unix /home/vagrant/pyenv.tail
 

--- a/setup.sh
+++ b/setup.sh
@@ -21,9 +21,9 @@ apt-get upgrade
 # https://github.com/bbcmicrobit/micropython/issues/514
 # Ubuntu 18.04 arm-none-eabi-gcc has broken libc/nano specs (always tries to use full arm w/invalid instructions)
 rm *.deb
-wget http://mirrors.kernel.org/ubuntu/pool/universe/n/newlib/libnewlib-dev_3.0.0.20180802-2_all.deb
-wget http://mirrors.kernel.org/ubuntu/pool/universe/n/newlib/libnewlib-arm-none-eabi_3.0.0.20180802-2_all.deb
-dpkg -i libnewlib-arm-none-eabi_3.0.0.20180802-2_all.deb libnewlib-dev_3.0.0.20180802-2_all.deb 
+wget http://mirrors.kernel.org/ubuntu/pool/universe/n/newlib/libnewlib-doc_3.1.0.20181231-1_all.deb 
+wget http://mirrors.kernel.org/ubuntu/pool/universe/n/newlib/libnewlib-arm-none-eabi_3.1.0.20181231-1_all.deb
+dpkg -i libnewlib-arm-none-eabi_3.1.0.20181231-1_all.deb libnewlib-doc_3.1.0.20181231-1_all.deb 
 
 # pip installs
 python3 -m pip install --upgrade pip


### PR DESCRIPTION
'vagrant up' fails with the following error message

default: # https://github.com/bbcmicrobit/micropython/issues/514
default: # Ubuntu 18.04 arm-none-eabi-gcc has broken libc/nano specs (always tries to use full arm w/invalid instructions)
default: wget http://mirrors.kernel.org/ubuntu/pool/universe/n/newlib/libnewlib-dev_3.0.0.20180802-2_all.deb
default: --2020-02-21 17:19:20--  http://mirrors.kernel.org/ubuntu/pool/universe/n/newlib/libnewlib-dev_3.0.0.20180802-2_all.deb
default: Resolving mirrors.kernel.org (mirrors.kernel.org)... 
default: 198.145.21.9
default: , 
default: 2001:4f8:4:6f:0:1994:3:14
default: Connecting to mirrors.kernel.org (mirrors.kernel.org)|198.145.21.9|:80... 
default: connected.
default: HTTP request sent, awaiting response... 
default: 301 Moved Permanently
default: Location: http://mirrors.edge.kernel.org/ubuntu/pool/universe/n/newlib/libnewlib-dev_3.0.0.20180802-2_all.deb [following]
default: --2020-02-21 17:19:20--  http://mirrors.edge.kernel.org/ubuntu/pool/universe/n/newlib/libnewlib-dev_3.0.0.20180802-2_all.deb
default: Resolving mirrors.edge.kernel.org (mirrors.edge.kernel.org)... 
default: 147.75.197.195
default: , 
default: 2604:1380:1:3600::1
default: Connecting to mirrors.edge.kernel.org (mirrors.edge.kernel.org)|147.75.197.195|:80... 
default: connected.
default: HTTP request sent, awaiting response... 
default: 404 Not Found
default: 2020-02-21 17:19:20 ERROR 404: Not Found.
default: Makefile:4: recipe for target 'all' failed
default: make: *** [all] Error 8
